### PR TITLE
XSPfnc.s: fix _xsp_divy_get()'s value in the case of an invalid index.

### DIFF
--- a/XSP/XSPfnc.s
+++ b/XSP/XSPfnc.s
@@ -512,6 +512,7 @@ A7ID	=	4			*   スタック上 return先アドレス  [ 4 byte ]
 		move.w	(a0,d0.w),d0		* dl.w = *(short *)(#divy_AB + i * 2)
 		rts
 
+@@:
 	move.w	#-1, d0			* 無効な引数の場合はエラーとして -1 を返す
 	rts
 


### PR DESCRIPTION
Suggested solution for https://github.com/yosshin4004/x68k_xsp/issues/1 . 

_xsp_divy_get was missing a local label that should cause -1 to be returned in the event that the parameter is invalid. Presently, it jumps into the body of _xsp_min_divh_set, and modifies min_divh, possibly bypassing the limit checks enforced for that variable as well.